### PR TITLE
Bump to 1.18.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ java {
 }
 
 remapJar{
-    classifier = "1.18"
+    classifier = "1.18.1"
 }
 
 jar {
@@ -89,9 +89,9 @@ curseforge {
             id = '493679'
             changelog = project.changelog
             releaseType = project.releaseType.toLowerCase()
-            addGameVersion '1.18'
+            addGameVersion '1.18.1'
             mainArtifact(remapJar) {
-                displayName = "DiscordIntegration-Fabric $version (MC 1.18)"
+                displayName = "DiscordIntegration-Fabric $version (MC 1.18.1)"
             }
             relations {
                 requiredDependency 'fabric-api'
@@ -107,11 +107,11 @@ task publishModrinth (type: TaskModrinthUpload){
     if (project.hasProperty('modrinth.apikey')) { // $GRADLE_USER_HOME/gradle.properties
         token = getProperty("modrinth.apikey") // Use an environment property!
         projectId = 'rbJ7eS5V'
-        versionNumber = version+"-fabric-1.18"
-        versionName = "DiscordIntegration-Fabric $version (MC 1.18)"
+        versionNumber = version+"-fabric-1.18.1"
+        versionName = "DiscordIntegration-Fabric $version (MC 1.18.1)"
         uploadFile = remapJar
         changelog = project.changelog
-        addGameVersion('1.18')
+        addGameVersion('1.18.1')
         addLoader('fabric')
         versionType = project.releaseType.toUpperCase()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,16 +2,16 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18
-yarn_mappings=1.18+build.1
-loader_version=0.12.6
+minecraft_version=1.18.1
+yarn_mappings=1.18.1+build.2
+loader_version=0.12.11
 # Mod Properties
 maven_group=de.erdbeerbaerlp.dcintegration.fabric
 archives_base_name=dcintegration-fabric
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.43.1+1.18
+fabric_version=0.44.0+1.18
 
-mod_version=2.3.5
-changelog=Update to 1.18\nUse the 1.17 Player API version
+mod_version=2.3.6
+changelog=Update to 1.18.1
 releaseType = BETA

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -17,9 +17,9 @@
     "dcintegration-fabric.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.12.3",
+    "fabricloader": ">=0.12.9",
     "fabric": "*",
-    "minecraft": "1.18",
+    "minecraft": "1.18.1",
     "player_events_api": ">=2.0.0"
   }
 }


### PR DESCRIPTION
I just went in and changed all the numbers, lol; it works fine so far on my server. I also changed the loader requirement to 0.12.9, which contains a fix for the log4j exploit, just as a bit of an incentive.