### PR TITLE
Updated onDisconnect mixin (bugbusting):

### DIFF
--- a/src/main/java/de/erdbeerbaerlp/dcintegration/fabric/mixin/NetworkHandlerMixin.java
+++ b/src/main/java/de/erdbeerbaerlp/dcintegration/fabric/mixin/NetworkHandlerMixin.java
@@ -10,6 +10,7 @@ import de.erdbeerbaerlp.dcintegration.common.util.TextColors;
 import de.erdbeerbaerlp.dcintegration.fabric.DiscordIntegrationMod;
 import de.erdbeerbaerlp.dcintegration.fabric.util.FabricMessageUtils;
 import net.dv8tion.jda.api.EmbedBuilder;
+import net.minecraft.network.DisconnectionInfo;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
@@ -32,13 +33,13 @@ public class NetworkHandlerMixin {
      * Handle possible timeout
      */
     @Inject(method = "onDisconnected", at = @At("HEAD"))
-    private void onDisconnect(final Text textComponent, CallbackInfo ci) {
-        if (textComponent.equals(Text.translatable("disconnect.timeout")))
+    private void onDisconnect(DisconnectionInfo info, CallbackInfo ci) {
+        if (info.reason().equals(Text.translatable("disconnect.timeout")))
             DiscordIntegrationMod.timeouts.add(this.player.getUuid());
     }
 
     @Inject(at = @At(value = "HEAD"), method = "onDisconnected")
-    private void onPlayerLeave(Text reason, CallbackInfo info) {
+    private void onPlayerLeave(DisconnectionInfo info, CallbackInfo ci) {
         if (DiscordIntegrationMod.stopped) return; //Try to fix player leave messages after stop!
         if (LinkManager.isPlayerLinked(player.getUuid()) && LinkManager.getLink(null, player.getUuid()).settings.hideFromDiscord)
             return;


### PR DESCRIPTION
### Updated onDisconnect mixin, addressing this error:

``` Mixin apply for mod dcintegration-fabric failed dcintegration-fabric.mixins.json:NetworkHandlerMixin from mod dcintegration-fabric -> net.minecraft.class_3244: org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException Invalid descriptor on dcintegration-fabric.mixins.json:NetworkHandlerMixin from mod dcintegration-fabric->@Inject::onDisconnect(Lnet/minecraft/class_2561;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V! Expected (Lnet/minecraft/class_9812;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V but found (Lnet/minecraft/class_2561;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V [INJECT Applicator Phase -> dcintegration-fabric.mixins.json:NetworkHandlerMixin from mod dcintegration-fabric -> Apply Injections ->  -> Inject -> dcintegration-fabric.mixins.json:NetworkHandlerMixin from mod dcintegration-fabric->@Inject::onDisconnect(Lnet/minecraft/class_2561;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V]
    org.spongepowered.asm.mixin.injection.throwables.InvalidInjectionException: Invalid descriptor on dcintegration-fabric.mixins.json:NetworkHandlerMixin from mod dcintegration-fabric->@Inject::onDisconnect(Lnet/minecraft/class_2561;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V! Expected (Lnet/minecraft/class_9812;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V but found (Lnet/minecraft/class_2561;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V [INJECT Applicator Phase -> dcintegration-fabric.mixins.json:NetworkHandlerMixin from mod dcintegration-fabric -> Apply Injections ->  -> Inject -> dcintegration-fabric.mixins.json:NetworkHandlerMixin from mod dcintegration-fabric->@Inject::onDisconnect(Lnet/minecraft/class_2561;Lorg/spongepowered/asm/mixin/injection/callback/CallbackInfo;)V] ```